### PR TITLE
repository show page now shows the 10 most recently indexed collections

### DIFF
--- a/app/controllers/arclight/repositories_controller.rb
+++ b/app/controllers/arclight/repositories_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Arclight
+    # Controller for our /repositories index page
+    class RepositoriesController < ApplicationController
+      def index
+        @repositories = Arclight::Repository.all
+        load_collection_counts
+      end
+  
+      def show
+        @repository = Arclight::Repository.find_by!(slug: params[:id])
+        search_service = Blacklight.repository_class.new(blacklight_config)
+        @response = search_service.search(
+          q: "level_sim:Collection repository_sim:\"#{@repository.name}\"",
+          sort: "timestamp desc", 
+          rows: 10
+        )
+        @collections = @response.documents
+      end
+  
+      private
+  
+      def load_collection_counts
+        counts = fetch_collection_counts
+        @repositories.each do |repository|
+          repository.collection_count = counts[repository.name] || 0
+        end
+      end
+  
+      def fetch_collection_counts
+        search_service = Blacklight.repository_class.new(blacklight_config)
+        results = search_service.search(
+          q: 'level_sim:Collection',
+          'facet.field': 'repository_sim',
+          rows: 0
+        )
+        Hash[*results.facet_fields['repository_sim']]
+      end
+    end
+  end
+  


### PR DESCRIPTION
The repositories controller now used the Solr sort command to return the 10 most recently indexed collections. Before, it just returned the 100 first collections indexed. You can also change the `rows` field to customize how many collections are shown.