### PR TITLE
Fixed issue with container lists displaying collection level components

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -97,6 +97,8 @@ class CatalogController < ApplicationController
     config.add_facet_field 'geogname_sim', label: 'Place', limit: 10
     config.add_facet_field 'places_ssim', label: 'Places', show: false
     config.add_facet_field 'access_subjects_ssim', label: 'Subject', limit: 10
+    config.add_facet_field 'component_level_isim', show: false
+    config.add_facet_field 'parent_ssim', show: false
     config.add_facet_field 'genreform_sim', label: 'Format', limit: 10  #senylrc
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request


### PR DESCRIPTION
Previously, container lists would show other components from elsewhere in the collection.

![image](https://user-images.githubusercontent.com/10030353/116278974-fede3900-a754-11eb-9557-2c28a2b43f55.png)

I think there was some point when the ArcLight install script forgot a line or was missing some documentation I found the same thing in the UAlbany Arclight instance. These two facet fields need to be added for ArcLight to work.

Basically, the container list display is just a different rendering of search results. Arclight required these two facet fields that do not display to limit results to only children that have the current component listed as a parent. Without these facets, the "search results" return all more components that are not children of the current component, such as the collection-level.