### PR TITLE
Render html in otherfindaid

### DIFF
--- a/app/controllers/concerns/arclight/ead_format_helpers.rb
+++ b/app/controllers/concerns/arclight/ead_format_helpers.rb
@@ -8,12 +8,16 @@ module Arclight
     include ActionView::Helpers::OutputSafetyHelper
 
     def render_html_tags(args)
-      values = args[:value] || []
-      values.map! do |value|
-        transform_ead_to_html(value)
+      if args.is_a? String
+	transform_ead_to_html(args)
+      else	
+        values = args[:value] || []
+        values.map! do |value|
+          transform_ead_to_html(value)
+        end
+        values.map! { |value| wrap_in_paragraph(value) } if values.count > 1
+        safe_join(values.map(&:html_safe))
       end
-      values.map! { |value| wrap_in_paragraph(value) } if values.count > 1
-      safe_join(values.map(&:html_safe))
     end
 
     private

--- a/app/views/catalog/_custom_metadata.html.erb
+++ b/app/views/catalog/_custom_metadata.html.erb
@@ -23,7 +23,7 @@
                 <% end %>
                 Container List</a>
               <% else %>
-                <%= render_html_tags(otherfindaid.html_safe) %>
+                <%= render_html_tags(otherfindaid).html_safe %>
               <% end %>
             <% end %>
           </dd>

--- a/app/views/catalog/_custom_metadata.html.erb
+++ b/app/views/catalog/_custom_metadata.html.erb
@@ -23,7 +23,7 @@
                 <% end %>
                 Container List</a>
               <% else %>
-                <%= otherfindaid.html_safe %>
+                <%= render_html_tags(otherfindaid.html_safe) %>
               <% end %>
             <% end %>
           </dd>


### PR DESCRIPTION
`render_html_tags` now works for the otherfindaid field again and HTML there, such as `<a>` links should now render correctly again. 