### PR TITLE
Will now expose JSON API for components with metadata fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -253,6 +253,27 @@ class CatalogController < ApplicationController
     ]
 
     # ===========================
+    # JSON DATA FIELDS
+    # ===========================
+
+    config.add_show_field 'title_ssm', label: 'Title'
+    config.add_show_field 'normalized_title_ssm', label: 'Normalized title'
+    config.add_show_field 'normalized_date_ssm', label: 'Normalized date'
+    config.add_show_field 'unitdate_ssm', label: 'Unitdate'
+    config.add_show_field 'collection_ssm', label: 'Collection'
+    config.add_show_field 'repository_ssm', label: 'Repository'
+    config.add_show_field 'level_ssm', label: 'Level'
+    config.add_show_field 'component_level_isim', label: 'Component level'
+    config.add_show_field 'parent_ssim', label: 'Parent'
+    config.add_show_field 'parent_unittitles_ssm', label: 'Patent titles'
+    config.add_show_field 'ead_ssi', label: 'EAD ID'
+    config.add_show_field 'collection_unitid_ssm', label: 'Collection unit ID'
+    config.add_show_field 'has_online_content_ssim', label: 'Has online content?'
+    config.add_show_field 'child_component_count_isim', label: 'Child component count'
+    config.add_show_field 'title_filing_si', label: 'Filing title'
+    config.add_show_field 'otherfindaid_ssm', label: 'Other finding aids'
+
+    # ===========================
     # COLLECTION SHOW PAGE FIELDS
     # ===========================
 


### PR DESCRIPTION
This config exposes new fields to the JSON API for components. [Currently, this works but there's not much there](https://www.empireadc.org/search/catalog/nanb_4714.json).

[This example shows what this change will do](https://archives.albany.edu/description/catalog/apap392.json).

This will make it possible to write a script to index text from linked PDF inventories.

 